### PR TITLE
降低能耗

### DIFF
--- a/app/src/main/java/com/android/skip/data/config/ConfigLoadRepository.kt
+++ b/app/src/main/java/com/android/skip/data/config/ConfigLoadRepository.kt
@@ -43,7 +43,7 @@ class ConfigLoadRepository @Inject constructor() {
             }
         }
 
-        return withContext(Dispatchers.Main) {
+        return withContext(Dispatchers.Default) {
             try {
                 val skipByTextTasks =
                     createSkipByTextTasks(this, rootNode, targetConfig?.skipTexts, activityName)
@@ -102,7 +102,7 @@ class ConfigLoadRepository @Inject constructor() {
 
                 val targetNode = if (foundNode != null) {
                     if (skipText.length != null) {
-                        if (foundNode.text != null && foundNode.text.length <= skipText.length) {
+                        if (foundNode.text != null && foundNode.text.length <= skipText.length + 2) {
                             foundNode
                         } else {
                             null
@@ -114,16 +114,16 @@ class ConfigLoadRepository @Inject constructor() {
                     null
                 }
 
-                if (targetNode != null) {
+                targetNode?.let {
                     if (skipText.click != null) {
-                        skipText.click
+                        withContext(Dispatchers.Main){
+                            skipText.click
+                        }
                     } else {
                         val rect = Rect()
                         targetNode.getBoundsInScreen(rect)
                         rect
                     }
-                } else {
-                    null
                 }
             })
         }
@@ -144,16 +144,14 @@ class ConfigLoadRepository @Inject constructor() {
             deferredResults.add(scope.async {
                 val foundNode = rootNode.findAccessibilityNodeInfosByViewId(skipId.id).firstOrNull()
 
-                if (foundNode != null) {
+                foundNode?.let {
                     if (skipId.click != null) {
-                        skipId.click
+                        withContext(Dispatchers.Main){ skipId.click }
                     } else {
                         val rect = Rect()
                         foundNode.getBoundsInScreen(rect)
                         rect
                     }
-                } else {
-                    null
                 }
             })
         }
@@ -175,7 +173,7 @@ class ConfigLoadRepository @Inject constructor() {
             deferredResults.add(scope.async {
                 val foundRect = traverseNode(rootNode, skipBound.bound)
 
-                skipBound.click ?: foundRect
+                withContext(Dispatchers.Main) { skipBound.click ?: foundRect }
             })
         }
         return deferredResults

--- a/app/src/main/java/com/android/skip/data/config/ConfigLoadRepository.kt
+++ b/app/src/main/java/com/android/skip/data/config/ConfigLoadRepository.kt
@@ -1,6 +1,7 @@
 package com.android.skip.data.config
 
 import android.graphics.Rect
+import android.util.Log
 import android.view.accessibility.AccessibilityNodeInfo
 import com.android.skip.R
 import com.android.skip.dataclass.ConfigLoadSchema
@@ -115,15 +116,23 @@ class ConfigLoadRepository @Inject constructor() {
                 }
 
                 targetNode?.let {
-                    if (skipText.click != null) {
-                        withContext(Dispatchers.Main){
-                            skipText.click
-                        }
+                    // 优先尝试直接节点点击
+                    if (it.performAction(AccessibilityNodeInfo.ACTION_CLICK)) {
+                        // 点击成功，无需返回矩形
+                        null  // 注意：这里需要让调用方知道已点击，不再执行手势
                     } else {
-                        val rect = Rect()
-                        targetNode.getBoundsInScreen(rect)
-                        rect
+                        if (skipText.click != null) {
+                            // 使用配置的固定区域，后续手势点击（因为无法通过节点点击）
+                            skipText.click
+                        } else {
+                            // 节点点击失败，回退到坐标手势
+                            val rect = Rect()
+                            it.getBoundsInScreen(rect)
+                            rect
+
+                        }
                     }
+
                 }
             })
         }
@@ -146,7 +155,7 @@ class ConfigLoadRepository @Inject constructor() {
 
                 foundNode?.let {
                     if (skipId.click != null) {
-                        withContext(Dispatchers.Main){ skipId.click }
+                        skipId.click
                     } else {
                         val rect = Rect()
                         foundNode.getBoundsInScreen(rect)
@@ -173,7 +182,7 @@ class ConfigLoadRepository @Inject constructor() {
             deferredResults.add(scope.async {
                 val foundRect = traverseNode(rootNode, skipBound.bound)
 
-                withContext(Dispatchers.Main) { skipBound.click ?: foundRect }
+                skipBound.click ?: foundRect
             })
         }
         return deferredResults

--- a/app/src/main/java/com/android/skip/data/config/ConfigLoadRepository.kt
+++ b/app/src/main/java/com/android/skip/data/config/ConfigLoadRepository.kt
@@ -50,13 +50,7 @@ class ConfigLoadRepository @Inject constructor() {
         return withContext(Dispatchers.Default) {
             try {
                 val skipByTextTasks =
-                    createSkipByTextTasks(
-                        this,
-                        rootNode,
-                        targetConfig?.skipTexts,
-                        activityName,
-                        isShowTip
-                    )
+                    createSkipByTextTasks(this, rootNode, targetConfig?.skipTexts, activityName, isShowTip)
                 val skipByIdTasks =
                     createSkipByIdTasks(this, rootNode, targetConfig?.skipIds, activityName)
                 val skipByBoundTasks =

--- a/app/src/main/java/com/android/skip/data/config/ConfigLoadRepository.kt
+++ b/app/src/main/java/com/android/skip/data/config/ConfigLoadRepository.kt
@@ -1,13 +1,13 @@
 package com.android.skip.data.config
 
 import android.graphics.Rect
-import android.util.Log
 import android.view.accessibility.AccessibilityNodeInfo
 import com.android.skip.R
 import com.android.skip.dataclass.ConfigLoadSchema
 import com.android.skip.dataclass.LoadSkipBound
 import com.android.skip.dataclass.LoadSkipId
 import com.android.skip.dataclass.LoadSkipText
+import com.android.skip.util.MyToast
 import com.blankj.utilcode.util.LogUtils
 import com.blankj.utilcode.util.StringUtils.getString
 import kotlinx.coroutines.CoroutineScope
@@ -28,7 +28,10 @@ class ConfigLoadRepository @Inject constructor() {
     }
 
     suspend fun getTargetRect(
-        rootNode: AccessibilityNodeInfo, activityName: String?, isStrict: Boolean?
+        rootNode: AccessibilityNodeInfo,
+        activityName: String?,
+        isStrict: Boolean?,
+        isShowTip: Boolean
     ): Rect? {
         val targetAppPackage = rootNode.packageName.toString()
         var targetConfig = configLoadSchemaMap[targetAppPackage]
@@ -47,7 +50,13 @@ class ConfigLoadRepository @Inject constructor() {
         return withContext(Dispatchers.Default) {
             try {
                 val skipByTextTasks =
-                    createSkipByTextTasks(this, rootNode, targetConfig?.skipTexts, activityName)
+                    createSkipByTextTasks(
+                        this,
+                        rootNode,
+                        targetConfig?.skipTexts,
+                        activityName,
+                        isShowTip
+                    )
                 val skipByIdTasks =
                     createSkipByIdTasks(this, rootNode, targetConfig?.skipIds, activityName)
                 val skipByBoundTasks =
@@ -90,7 +99,8 @@ class ConfigLoadRepository @Inject constructor() {
         scope: CoroutineScope,
         rootNode: AccessibilityNodeInfo,
         skipTexts: List<LoadSkipText>?,
-        activityName: String?
+        activityName: String?,
+        isShowTip: Boolean
     ): List<Deferred<Rect?>> {
         val deferredResults = mutableListOf<Deferred<Rect?>>()
         if (skipTexts.isNullOrEmpty()) return deferredResults
@@ -118,7 +128,10 @@ class ConfigLoadRepository @Inject constructor() {
                 targetNode?.let {
                     // 优先尝试直接节点点击
                     if (it.performAction(AccessibilityNodeInfo.ACTION_CLICK)) {
-                        // 点击成功，无需返回矩形
+                        // 点击成功
+                        if (isShowTip) {
+                            MyToast.show(R.string.toast_skip_tip)
+                        }
                         null  // 注意：这里需要让调用方知道已点击，不再执行手势
                     } else {
                         if (skipText.click != null) {
@@ -129,7 +142,6 @@ class ConfigLoadRepository @Inject constructor() {
                             val rect = Rect()
                             it.getBoundsInScreen(rect)
                             rect
-
                         }
                     }
 

--- a/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
+++ b/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
@@ -2,6 +2,10 @@ package com.android.skip.service
 
 import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.GestureDescription
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.Path
 import android.graphics.Rect
 import android.util.Log
@@ -86,8 +90,34 @@ class MyAccessibilityService : AccessibilityService() {
 
     private val strictObserver = Observer<Boolean> { isStrict = it }
 
+    private var isScreenOn = true
+
+    private val screenStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            when (intent.action) {
+                Intent.ACTION_SCREEN_ON -> {isScreenOn = true
+                    LogUtils.d("亮屏")
+                }
+                Intent.ACTION_SCREEN_OFF -> {
+                    isScreenOn = false
+                    LogUtils.d("息屏")
+                }
+            }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        val filter = IntentFilter().apply {
+            addAction(Intent.ACTION_SCREEN_ON)
+            addAction(Intent.ACTION_SCREEN_OFF)
+        }
+        registerReceiver(screenStateReceiver, filter)
+    }
+
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         try {
+            if(!isScreenOn) return    // 息屏直接返回
             if(!event.isUseful()) return
             val packageName = event.packageName?.toString() ?: return
             if (whiteListRepository.isAppInWhiteList(packageName)) return  // 过滤白名单
@@ -176,6 +206,7 @@ class MyAccessibilityService : AccessibilityService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        unregisterReceiver(screenStateReceiver)
         serviceScope.cancel()
         startAccessibilityRepository.changeAccessibilityState(AccessibilityState.STOPPED)
 

--- a/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
+++ b/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
@@ -23,6 +23,7 @@ import com.android.skip.ui.whitelist.WhiteListRepository
 import com.android.skip.util.AccessibilityState
 import com.android.skip.util.AccessibilityStateUtils
 import com.android.skip.util.MyToast
+import com.android.skip.util.isUseful
 import com.blankj.utilcode.util.AppUtils
 import com.blankj.utilcode.util.LogUtils
 import com.blankj.utilcode.util.ScreenUtils
@@ -87,11 +88,8 @@ class MyAccessibilityService : AccessibilityService() {
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         try {
-            if(event?.eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED &&
-                event?.eventType != AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED) return
-
+            if(!event.isUseful()) return
             val packageName = event.packageName?.toString() ?: return
-
             if (whiteListRepository.isAppInWhiteList(packageName)) return  // 过滤白名单
 
             if (packageName != appPackageName) {
@@ -217,8 +215,7 @@ class MyAccessibilityService : AccessibilityService() {
         }
     }
 
-    private fun getActivityName(event: AccessibilityEvent?): String? {
-        event ?: return null
+    private fun getActivityName(event: AccessibilityEvent): String? {
         val className = event.className
 
         className ?: return null

--- a/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
+++ b/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
@@ -98,7 +98,7 @@ class MyAccessibilityService : AccessibilityService() {
                 appPackageName = packageName
             }
 
-            Log.d("SKIP_APP",
+            LogUtils.d(
                 "onAccessibilityEvent: ${event.eventType} and scanTime =$scanTimes\n appPackageName =$appPackageName"
             )
 

--- a/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
+++ b/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
@@ -87,7 +87,8 @@ class MyAccessibilityService : AccessibilityService() {
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         try {
-            if(event?.eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) return
+            if(event?.eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED &&
+                event?.eventType != AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED) return
 
             val packageName = event.packageName?.toString() ?: return
 
@@ -100,7 +101,7 @@ class MyAccessibilityService : AccessibilityService() {
             }
 
             Log.d("SKIP_APP",
-                "onAccessibilityEvent: WINDOW_STATE_CHANGED and scanTime =$scanTimes\n appPackageName =$appPackageName"
+                "onAccessibilityEvent: ${event.eventType} and scanTime =$scanTimes\n appPackageName =$appPackageName"
             )
 
             val rootNode = getCurrentRootNode() ?: return
@@ -114,7 +115,7 @@ class MyAccessibilityService : AccessibilityService() {
                 val that = this
                 serviceScope.launch {
                     val targetRect =
-                        configLoadRepository.getTargetRect(rootNode, appActivityName, isStrict)
+                        configLoadRepository.getTargetRect(rootNode, appActivityName, isStrict, isShowTip)
                     targetRect?.let { rect ->
                         val rectStr = rect.toString()
                         if(clickedRect.add(rectStr)){

--- a/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
+++ b/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
@@ -4,6 +4,7 @@ import android.accessibilityservice.AccessibilityService
 import android.accessibilityservice.GestureDescription
 import android.graphics.Path
 import android.graphics.Rect
+import android.util.Log
 import android.view.KeyEvent
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
@@ -20,6 +21,7 @@ import com.android.skip.ui.settings.strict.StrictRepository
 import com.android.skip.ui.settings.tip.TipRepository
 import com.android.skip.ui.whitelist.WhiteListRepository
 import com.android.skip.util.AccessibilityState
+import com.android.skip.util.AccessibilityStateUtils
 import com.android.skip.util.MyToast
 import com.blankj.utilcode.util.AppUtils
 import com.blankj.utilcode.util.LogUtils
@@ -83,16 +85,24 @@ class MyAccessibilityService : AccessibilityService() {
 
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         try {
-            val rootNode = getCurrentRootNode()
+            if(event?.eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) return
 
-            val rootNodePackageName = rootNode.packageName.toString()
-            if (rootNodePackageName != appPackageName) {
+            val packageName = event.packageName?.toString() ?: return
+
+            Log.d("SKIP_APP",
+                "onAccessibilityEvent: WINDOW_STATE_CHANGED and scanTime =$scanTimes\n appPackageName =$appPackageName"
+            )
+
+            if (whiteListRepository.isAppInWhiteList(packageName)) return  // 过滤白名单
+
+            if (packageName != appPackageName) {
                 scanTimes = 0
                 clickedRect.clear()
-                appPackageName = rootNodePackageName
+                appPackageName = packageName
             }
 
-            if (!whiteListRepository.isAppInWhiteList(rootNodePackageName) && (isStrict || scanTimes < 50)) {
+            val rootNode = getCurrentRootNode() ?: return
+            if (isStrict || scanTimes < 10) {
                 val that = this
                 serviceScope.launch {
                     val targetRect =
@@ -104,7 +114,7 @@ class MyAccessibilityService : AccessibilityService() {
                                 click(that, rect)
                             }
                             clickedRect.add(rectStr)
-                            LogUtils.d("clicked: packageName is $rootNodePackageName rect is $rectStr")
+                            LogUtils.d("clicked: packageName is $packageName rect is $rectStr")
                         }
                     }
                 }
@@ -122,7 +132,7 @@ class MyAccessibilityService : AccessibilityService() {
             }
 
             scanTimes++
-        } catch (e: Exception) {
+            } catch (e: Exception) {
             LogUtils.e(e)
         }
     }
@@ -189,8 +199,8 @@ class MyAccessibilityService : AccessibilityService() {
         return super.onKeyEvent(event)
     }
 
-    private fun getCurrentRootNode(): AccessibilityNodeInfo {
-        return rootInActiveWindow ?: throw IllegalStateException("No valid root node available")
+    private fun getCurrentRootNode(): AccessibilityNodeInfo? {
+        return rootInActiveWindow
     }
 
     private fun isSystemClass(className: String): Boolean {

--- a/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
+++ b/app/src/main/java/com/android/skip/service/MyAccessibilityService.kt
@@ -36,6 +36,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
 
@@ -47,7 +49,7 @@ class MyAccessibilityService : AccessibilityService() {
     private var isStrict: Boolean = false
     private var scanTimes: Int = 0
 
-    private val clickedRect: MutableSet<String> = mutableSetOf()
+    private val clickedRect = Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
     private val serviceScope = CoroutineScope(Dispatchers.Default + Job())
 
     @Inject
@@ -89,10 +91,6 @@ class MyAccessibilityService : AccessibilityService() {
 
             val packageName = event.packageName?.toString() ?: return
 
-            Log.d("SKIP_APP",
-                "onAccessibilityEvent: WINDOW_STATE_CHANGED and scanTime =$scanTimes\n appPackageName =$appPackageName"
-            )
-
             if (whiteListRepository.isAppInWhiteList(packageName)) return  // 过滤白名单
 
             if (packageName != appPackageName) {
@@ -101,7 +99,17 @@ class MyAccessibilityService : AccessibilityService() {
                 appPackageName = packageName
             }
 
+            Log.d("SKIP_APP",
+                "onAccessibilityEvent: WINDOW_STATE_CHANGED and scanTime =$scanTimes\n appPackageName =$appPackageName"
+            )
+
             val rootNode = getCurrentRootNode() ?: return
+            val rootPackageName = rootNode.packageName.toString()
+            if( rootPackageName != packageName ) return
+            getActivityName(event)?.let {
+                appActivityName = it
+            }
+
             if (isStrict || scanTimes < 10) {
                 val that = this
                 serviceScope.launch {
@@ -109,19 +117,14 @@ class MyAccessibilityService : AccessibilityService() {
                         configLoadRepository.getTargetRect(rootNode, appActivityName, isStrict)
                     targetRect?.let { rect ->
                         val rectStr = rect.toString()
-                        if (!clickedRect.contains(rectStr)) {
+                        if(clickedRect.add(rectStr)){
                             withContext(Dispatchers.Main) {
                                 click(that, rect)
                             }
-                            clickedRect.add(rectStr)
                             LogUtils.d("clicked: packageName is $packageName rect is $rectStr")
                         }
                     }
                 }
-            }
-
-            getActivityName(event)?.let {
-                appActivityName = it
             }
 
             appActivityName?.let {

--- a/app/src/main/java/com/android/skip/ui/whitelist/WhiteListRepository.kt
+++ b/app/src/main/java/com/android/skip/ui/whitelist/WhiteListRepository.kt
@@ -40,6 +40,6 @@ class WhiteListRepository @Inject constructor() {
     }
 
     fun isAppInWhiteList(packageName: String): Boolean {
-        return _whiteList.indexOf(packageName) != -1
+        return _whiteList.contains(packageName)
     }
 }

--- a/app/src/main/java/com/android/skip/util/AccessibilityExt.kt
+++ b/app/src/main/java/com/android/skip/util/AccessibilityExt.kt
@@ -1,0 +1,17 @@
+package com.android.skip.util
+
+import android.view.accessibility.AccessibilityEvent
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+const val STATE_CHANGED = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED
+const val CONTENT_CHANGED = AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
+
+private const val interestedEvents = STATE_CHANGED or CONTENT_CHANGED
+@OptIn(ExperimentalContracts::class)
+fun AccessibilityEvent?.isUseful(): Boolean {
+    contract {
+        returns(true) implies (this@isUseful != null)
+    }
+    return (this != null && packageName != null && className != null && eventType and interestedEvents != 0)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     <string name="toast_save_fail">保存失败</string>
     <string name="toast_del_success">删除成功</string>
     <string name="toast_del_fail">删除失败</string>
-    <string name="toast_skip_tip">Bro，已为您跳过广告</string>
+    <string name="toast_skip_tip">已为您跳过广告</string>
 
     <string name="record_please_choose">请选择一个应用来分享文件</string>
     <string name="record_look">查看</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     <string name="toast_save_fail">保存失败</string>
     <string name="toast_del_success">删除成功</string>
     <string name="toast_del_fail">删除失败</string>
-    <string name="toast_skip_tip">已为您跳过广告</string>
+    <string name="toast_skip_tip">Bro，已为您跳过广告</string>
 
     <string name="record_please_choose">请选择一个应用来分享文件</string>
     <string name="record_look">查看</string>
@@ -109,6 +109,7 @@
     <string name="store_default_config">https://skip.guoxicheng.top/skip_config_v3.yaml</string>
     <string name="store_strict_mode">STRICT_MODE</string>
     <string name="store_skip_tip">SKIP_TIP</string>
+    <string name="store_skip_tip_text">SKIP_TIP_TEXT</string>
     <string name="store_resident_notification_bar">RESIDENT_NOTIFICATION_BAR</string>
     <string name="store_exclude_from_recent">EXCLUDE_FROM_RECENT</string>
     <string name="store_auto_update">AUTO_UPDATE</string>


### PR DESCRIPTION
1. 通过卫语句、无障碍事件类型，过滤掉大部分不必要的检测
2. 若节点本身可以点击，则优先尝试直接点击
3. 使用可并发的Set，避免出现多次模拟点击的情况
4. 将部分协程移到后台协程
5. 拓宽文字匹配的长度限制，如“跳过广告”的情况